### PR TITLE
fixed slight bug in modules/memory.py

### DIFF
--- a/modules/memory.py
+++ b/modules/memory.py
@@ -161,7 +161,7 @@ class Memory(AbstractUnicornDbgModule):
         self.core_instance.get_emu_instance().mem_unmap(off, lent)
         mappings = self.core_instance.get_module('mappings_module').get_mappings()
         for i in range(0, len(mappings)):
-            if mappings[i][1] == off:
+            if int(mappings[i][1], 0) == off:
                 map_lent = mappings[i][2]
                 if map_lent == lent:
                     mappings.pop(i)


### PR DESCRIPTION
When unmapping memory regions with "memory unmap <addr> <length>", the region is not deleted in the mappings list and shows up in subsequent requests to view all memory maps.

![demo](https://user-images.githubusercontent.com/30490461/61078860-ddc12280-a3de-11e9-92cf-c63e1a27ce6b.PNG)

Fixed by changing `if mappings[i][1] == off` to `if int(mappings[i][1], 0) == off`