### PR TITLE
Fix ARM wrong pc addresses in decompilation

### DIFF
--- a/udbg/modules/asm.py
+++ b/udbg/modules/asm.py
@@ -30,6 +30,7 @@
 
 import capstone
 import keystone
+from unicorn import UC_ARCH_ARM, UC_ARCH_ARM64
 
 import udbg.utils as utils
 from udbg.modules.unicorndbgmodule import AbstractUnicornDbgModule
@@ -139,6 +140,8 @@ class ASM(AbstractUnicornDbgModule):
                 print(utils.green_bold(a) + "\t%s\t%s" % (i.mnemonic, i.op_str))
 
     def internal_disassemble(self, buf, off, current_off=0):
+        if self.core_instance.get_emu_instance()._arch == UC_ARCH_ARM or self.core_instance.get_emu_instance()._arch == UC_ARCH_ARM64:
+            current_off += 2
         cs = self.core_instance.get_cs_instance()
         for i in cs.disasm(bytes(buf), off):
             if i.address == current_off:

--- a/udbg/udbg.py
+++ b/udbg/udbg.py
@@ -410,6 +410,8 @@ class UnicornDbg(object):
         self.asm_module.internal_disassemble(uc.mem_read(start, 0x32), start, address)
 
     def _print_context(self, uc, pc):
+        if self.arch == UC_ARCH_ARM or self.arch == UC_ARCH_ARM64:
+            pc -= 2
         self.register_module.registers('mem_invalid')
         print(utils.titlify('disasm'))
         self.asm_module.internal_disassemble(uc.mem_read(pc - 0x16, 0x32), pc - 0x16, pc)


### PR DESCRIPTION
ARM disassembly was incorrect because of some weird ARM-architecture specific spec. The PC had to be offset by 2 for the disassembly to be correctly aligned again.